### PR TITLE
Added 'Disable Merging' option

### DIFF
--- a/Assets/Editor/LightProbes/LightProbePlacement.cs
+++ b/Assets/Editor/LightProbes/LightProbePlacement.cs
@@ -11,6 +11,7 @@ public class LightProbePlacement : EditorWindow {
 
 	float mergeDistance = 1;
 	GameObject probeObject;
+	bool disableMerging;
 
 	[MenuItem ("Window/Generate Light Probes")]
 	static void Init() {
@@ -34,7 +35,7 @@ public class LightProbePlacement : EditorWindow {
 
 				probe.transform.position = Vector3.zero;
 
-				NavMeshTriangulation navMesh = NavMesh.CalculateTriangulation ();
+				UnityEngine.AI.NavMeshTriangulation navMesh = UnityEngine.AI.NavMesh.CalculateTriangulation ();
 
 
 				current = "Generating necessary lists...";
@@ -63,13 +64,15 @@ public class LightProbePlacement : EditorWindow {
 						List<Vector3> nearbyProbes = new List<Vector3>();
 						nearbyProbes.Add (pro.point);
 						pro.used = true;
-						foreach(ProbeGenPoint pp in probeGen) {
-							if(pp.used == false) {
-								current = "Checking point at " + pro.point.ToString ();
-								//EditorUtility.DisplayProgressBar ("Generating probes", current, progress);
-								if(Vector3.Distance (pp.point, pro.point) <= mergeDistance) {
-									pp.used = true;
-									nearbyProbes.Add (pp.point);
+						if (!disableMerging) {
+							foreach(ProbeGenPoint pp in probeGen) {
+								if(pp.used == false) {
+									current = "Checking point at " + pro.point.ToString ();
+									//EditorUtility.DisplayProgressBar ("Generating probes", current, progress);
+									if(Vector3.Distance (pp.point, pro.point) <= mergeDistance) {
+										pp.used = true;
+										nearbyProbes.Add (pp.point);
+									}
 								}
 							}
 						}
@@ -116,9 +119,11 @@ public class LightProbePlacement : EditorWindow {
 			PlaceProbes ();
 		}
 		mergeDistance = EditorGUILayout.FloatField ("Vector merge distance",mergeDistance);
+		disableMerging = EditorGUILayout.Toggle ("Disable merging", disableMerging);
 		probeObject = (GameObject)EditorGUILayout.ObjectField ("Probe GameObject" , probeObject, typeof(GameObject), true);
 		EditorGUILayout.LabelField ("This script will automatically generate light probe positions based on the current navmesh.");
 		EditorGUILayout.LabelField ("Please make sure that you have generated a navmesh before using the script.");
+		EditorGUILayout.LabelField ("If your navmeh is very large or complex, try using 'Disable Merging' to tremendously speed up the process. Keep in mind this may produce more probes than necessary, which may negatively impact performance.");
 
 		if(working) {
 			EditorUtility.DisplayProgressBar ("Generating probes", current, progress);

--- a/Assets/Editor/LightProbes/LightProbePlacement.cs
+++ b/Assets/Editor/LightProbes/LightProbePlacement.cs
@@ -123,7 +123,7 @@ public class LightProbePlacement : EditorWindow {
 		probeObject = (GameObject)EditorGUILayout.ObjectField ("Probe GameObject" , probeObject, typeof(GameObject), true);
 		EditorGUILayout.LabelField ("This script will automatically generate light probe positions based on the current navmesh.");
 		EditorGUILayout.LabelField ("Please make sure that you have generated a navmesh before using the script.");
-		EditorGUILayout.LabelField ("If your navmeh is very large or complex, try using 'Disable Merging' to tremendously speed up the process. Keep in mind this may produce more probes than necessary, which may negatively impact performance.");
+		EditorGUILayout.LabelField ("If your navmesh is very large or complex, try using 'Disable Merging' to tremendously speed up the process. Keep in mind this may produce more probes than necessary, which may negatively impact performance.");
 
 		if(working) {
 			EditorUtility.DisplayProgressBar ("Generating probes", current, progress);


### PR DESCRIPTION
This tremendously speeds up the process but may produce more probes than necessary.

In my case, I was entirely unable to use this script to place light probes in my scene due to my NavMesh being far too complex. Waiting about 15 minutes only yielded a small sliver of progress. By disabling the 'merging' feature, the script was able to place all the probes in about a minute.

However, if you're able to use the probe merging feature, it would be best to do so. I added a note in the editor window to hopefully warn people enabling this option may negatively impact performance.